### PR TITLE
Initial CI config for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on: [push]
+
+jobs:
+  build_mac:
+    runs-on: macos-latest
+
+    defaults:
+      run:
+        working-directory: MacOS
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: xcodebuild -scheme display_switch -configuration release -derivedDataPath .build build
+      - uses: actions/upload-artifact@v1
+        with:
+          name: mac
+          path: MacOS/.build/Build/Products/release/display_switch
+
+  build_windows:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: Windows
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Run tests
+        run: cargo test --verbose
+      - uses: actions/upload-artifact@v1
+        with:
+          name: windows
+          path: Windows/target/release/display_switch.exe

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![build](https://github.com/haimgel/display-switch/workflows/build/badge.svg)
+
 # Turn a $30 USB switch into a full-featured KVM
 
 This utility watches for USB device connect/disconnect events and switches monitor inputs via DDC/CI. This turns


### PR DESCRIPTION
This PR configures CI via GitHub Actions, building for Mac and Windows on every commit and publishing the artifacts.

I haven't tried the binaries, but it ought to address #2 .