### PR TITLE
Add single DP support with switch back on removal

### DIFF
--- a/Windows/src/configuration.rs
+++ b/Windows/src/configuration.rs
@@ -13,7 +13,8 @@ use crate::display_control;
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
     pub usb_device: String,
-    pub monitor_input: display_control::InputSource,
+    pub monitor_input_added: display_control::InputSource,
+    pub monitor_input_removed: display_control::InputSource,
 }
 
 impl Configuration {

--- a/Windows/src/display_control.rs
+++ b/Windows/src/display_control.rs
@@ -17,10 +17,8 @@ const INPUT_SELECT: u8 = 0x60;
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub enum InputSource {
-    DisplayPort1 = 0x0f,
-    DisplayPort2 = 0x10,
+    DisplayPort1 = 0xf,
     Hdmi1 = 0x11,
-    Hdmi2 = 0x12,
 }
 
 pub fn log_current_source() -> Result<()> {

--- a/Windows/src/main.rs
+++ b/Windows/src/main.rs
@@ -18,12 +18,19 @@ fn main() {
     let config = configuration::Configuration::load().unwrap();
     let mut detector = usb_devices::UsbChangeDetector::new().unwrap();
     let pnp_detect = pnp_detect::PnPDetect::new(move || {
-        let added_devices = detector.detect_added_devices().unwrap();
-        debug!("Detected device change. Added devices: {:?}", added_devices);
-        if added_devices.contains(&config.usb_device) {
-            info!("Detected device we're looking for {:?}", &config.usb_device);
+        let changed_devices = detector.detect_changed_devices().unwrap();
+        debug!("Detected device change. Added devices: {:?}", changed_devices);
+        if changed_devices.added_devices.contains(&config.usb_device) {
+            info!("Detected added device we're looking for {:?}", &config.usb_device);
             display_control::wiggle_mouse();
-            display_control::switch_to(config.monitor_input).unwrap_or_else(|err| {
+            display_control::switch_to(config.monitor_input_added).unwrap_or_else(|err| {
+                error!("Cannot switch monitor input: {:?}", err);
+            });
+        }
+        if changed_devices.removed_devices.contains(&config.usb_device) {
+            info!("Detected removed device we're looking for {:?}", &config.usb_device);
+            display_control::wiggle_mouse();
+            display_control::switch_to(config.monitor_input_removed).unwrap_or_else(|err| {
                 error!("Cannot switch monitor input: {:?}", err);
             });
         }

--- a/Windows/src/usb_devices.rs
+++ b/Windows/src/usb_devices.rs
@@ -11,6 +11,13 @@ pub struct UsbChangeDetector {
     current_devices: HashSet<String>,
 }
 
+
+#[derive(Debug)]
+pub struct ChangedDevices {
+    pub added_devices: HashSet<String>,
+    pub removed_devices: HashSet<String>,
+}
+
 impl UsbChangeDetector {
     pub fn new() -> Result<UsbChangeDetector> {
         Ok(UsbChangeDetector {
@@ -18,11 +25,22 @@ impl UsbChangeDetector {
         })
     }
 
-    pub fn detect_added_devices(&mut self) -> Result<HashSet<String>> {
+    // pub fn detect_added_devices(&mut self) -> Result<HashSet<String>> {
+    //     let new_devices = Self::read_device_list()?;
+    //     let added_devices = &new_devices - &self.current_devices;
+    //     self.current_devices = new_devices;
+    //     return Ok(added_devices);
+    // }
+
+    pub fn detect_changed_devices(&mut self) -> Result<ChangedDevices> {
         let new_devices = Self::read_device_list()?;
         let added_devices = &new_devices - &self.current_devices;
+        let removed_devices = &self.current_devices - &new_devices;
         self.current_devices = new_devices;
-        return Ok(added_devices);
+        return Ok(ChangedDevices {
+            added_devices,
+            removed_devices,
+        });
     }
 
     fn read_device_list() -> Result<HashSet<String>> {


### PR DESCRIPTION
Just a quick draft for how I can use it with a single displayport input. Thus my windows system has to switch for both machines by detecting addition and removal of USB devices.

Feel free to merge, I just don't think you'll be interested to merge it with this exact change.