### PR TITLE
Support per-monitor input source configuration.

### DIFF
--- a/Windows/Cargo.lock
+++ b/Windows/Cargo.lock
@@ -159,7 +159,9 @@ dependencies = [
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusb 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Windows/Cargo.toml
+++ b/Windows/Cargo.toml
@@ -11,6 +11,8 @@ serde = { version = "1.0.114", features = ["derive"] }
 anyhow = "1.0.32"
 log = "0.4.11"
 simplelog = "0.8.0"
+toml = "0.5.6"
+serde_json = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "libloaderapi"] }

--- a/Windows/src/configuration.rs
+++ b/Windows/src/configuration.rs
@@ -7,18 +7,32 @@ use anyhow::{anyhow, Result};
 use config;
 use dirs;
 use serde::Deserialize;
+use std::fs;
 
 use crate::display_control;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
     pub usb_device: String,
     pub monitor_input: display_control::InputSource,
+    pub monitor_input_map: Option<HashMap<String, display_control::InputSource>>,
 }
 
 impl Configuration {
     pub fn load() -> Result<Self> {
-        let config_file_name = Self::config_file_name()?;
+        if let Ok(config) = Self::try_load_toml() {
+            return Ok(config);
+        }
+        if let Ok(config) = Self::try_load_json() {
+            return Ok(config);
+        }
+
+        Self::try_load_ini()
+    }
+
+    pub fn try_load_ini() -> Result<Self> {
+        let config_file_name = Self::config_file_name("ini")?;
         let mut settings = config::Config::default();
         settings
             .merge(config::File::from(config_file_name.to_path_buf()))?
@@ -31,12 +45,36 @@ impl Configuration {
         Ok(config)
     }
 
-    pub fn config_file_name() -> Result<std::path::PathBuf> {
+    pub fn try_load_toml() -> Result<Self> {
+        let config_data = Self::config_file_str("toml")?;
+        let config = toml::from_str::<Self>(&config_data)?;
+
+        info!("Configuration loaded from toml: {:?}", config);
+        Ok(config)
+    }
+
+    pub fn try_load_json() -> Result<Self> {
+        let config_data = Self::config_file_str("json")?;
+        let config = serde_json::from_str::<Self>(&config_data)?;
+
+        info!("Configuration loaded from toml: {:?}", config);
+        Ok(config)
+    }
+
+    pub fn config_file_name(extension: &str) -> Result<std::path::PathBuf> {
         let config_dir = dirs::config_dir()
             .ok_or(anyhow!("Config directory not found"))?
             .join("display-switch");
         std::fs::create_dir_all(&config_dir)?;
-        Ok(config_dir.join("display-switch.ini"))
+        Ok(config_dir.join(format!("display-switch.{}", extension)))
+    }
+
+    pub fn config_file_str(extension: &str) -> Result<String> {
+        let config_file_name = Self::config_file_name(extension)?;
+        let config_data = fs::read_to_string(&config_file_name)?;
+
+        info!("Configuration file found {:?}", config_file_name);
+        Ok(config_data)
     }
 
     pub fn log_file_name() -> Result<std::path::PathBuf> {

--- a/Windows/src/configuration.rs
+++ b/Windows/src/configuration.rs
@@ -16,7 +16,8 @@ use std::collections::HashMap;
 pub struct Configuration {
     pub usb_device: String,
     pub monitor_input: display_control::InputSource,
-    pub monitor_input_map: Option<HashMap<String, display_control::InputSource>>,
+    pub on_connect: Option<HashMap<String, display_control::InputSource>>,
+    pub on_disconnect: Option<HashMap<String, display_control::InputSource>>,
 }
 
 impl Configuration {

--- a/Windows/src/display_control.rs
+++ b/Windows/src/display_control.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashMap, thread::sleep};
 
 use anyhow::Result;
-use ddc::Ddc;
+use ddc::{Ddc, DdcHost};
 use ddc_winapi::Monitor;
 use serde::Deserialize;
 use winapi::_core::time::Duration;
@@ -36,6 +36,7 @@ pub fn switch_to(
     source_map: &Option<HashMap<String, InputSource>>,
 ) -> Result<()> {
     for mut ddc in Monitor::enumerate()? {
+        ddc.sleep();
         let handle_str: usize = ddc.handle() as *const _ as usize;
         let handle_str = format!("{:x}", handle_str);
 

--- a/Windows/src/display_control.rs
+++ b/Windows/src/display_control.rs
@@ -3,7 +3,7 @@
 // This code is licensed under MIT license (see LICENSE.txt for details)
 //
 
-use std::thread::sleep;
+use std::{collections::HashMap, thread::sleep};
 
 use anyhow::Result;
 use ddc::Ddc;
@@ -31,10 +31,21 @@ pub fn log_current_source() -> Result<()> {
     Ok(())
 }
 
-pub fn switch_to(source: InputSource) -> Result<()> {
+pub fn switch_to(
+    default_source: InputSource,
+    source_map: &Option<HashMap<String, InputSource>>,
+) -> Result<()> {
     for mut ddc in Monitor::enumerate()? {
+        let handle_str: usize = ddc.handle() as *const _ as usize;
+        let handle_str = format!("{:x}", handle_str);
+
+        let source = source_map
+            .as_ref()
+            .and_then(|m| m.get(&handle_str))
+            .unwrap_or(&default_source);
+
         info!("Setting monitor '{:?}' to {:?}", ddc, source);
-        ddc.set_vcp_feature(INPUT_SELECT, source as u16)?;
+        ddc.set_vcp_feature(INPUT_SELECT, *source as u16)?;
     }
     Ok(())
 }

--- a/Windows/src/main.rs
+++ b/Windows/src/main.rs
@@ -23,9 +23,10 @@ fn main() {
         if added_devices.contains(&config.usb_device) {
             info!("Detected device we're looking for {:?}", &config.usb_device);
             display_control::wiggle_mouse();
-            display_control::switch_to(config.monitor_input).unwrap_or_else(|err| {
-                error!("Cannot switch monitor input: {:?}", err);
-            });
+            display_control::switch_to(config.monitor_input, &config.monitor_input_map)
+                .unwrap_or_else(|err| {
+                    error!("Cannot switch monitor input: {:?}", err);
+                });
         }
     });
     display_control::log_current_source().unwrap_or_else(|err| {

--- a/Windows/src/usb_devices.rs
+++ b/Windows/src/usb_devices.rs
@@ -11,6 +11,12 @@ pub struct UsbChangeDetector {
     current_devices: HashSet<String>,
 }
 
+#[derive(Debug)]
+pub struct ChangedDevices {
+    pub added: HashSet<String>,
+    pub removed: HashSet<String>,
+}
+
 impl UsbChangeDetector {
     pub fn new() -> Result<UsbChangeDetector> {
         Ok(UsbChangeDetector {
@@ -18,11 +24,12 @@ impl UsbChangeDetector {
         })
     }
 
-    pub fn detect_added_devices(&mut self) -> Result<HashSet<String>> {
+    pub fn detect_changed_devices(&mut self) -> Result<ChangedDevices> {
         let new_devices = Self::read_device_list()?;
-        let added_devices = &new_devices - &self.current_devices;
+        let added = &new_devices - &self.current_devices;
+        let removed = &self.current_devices - &new_devices;
         self.current_devices = new_devices;
-        return Ok(added_devices);
+        return Ok(ChangedDevices { added, removed });
     }
 
     fn read_device_list() -> Result<HashSet<String>> {


### PR DESCRIPTION
The configuration is extended with a `monitor_input_map` property and JSON and TOML format support.

This allowed me to do this:

```toml
usb_device = "05e3:0610"
monitor_input = "DisplayPort1"

[monitor_input_map]
1 = "DisplayPort1"
2 = "Hdmi1
```