### PR TITLE
Feature/control other monitor input

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ Windows user name).
   cp dev.haim.display-switch.daemon.plist ~/Library/LaunchAgents/
   launchctl load ~/Library/LaunchAgents/dev.haim.display-switch.daemon.plist
 ```
+
+## Finding your usb information on a Mac
+
+On a Mac...install [home-brew](https://brew.sh). Use a regular keyboard not attached to the faux kvm.
+
+Open a terminal.
+
+```$ brew install lsusb
+
+$ lsusb > a
+
+$ lsusb > b
+$ opendiff a b
+```
+
+The lines that are highlighted should show you which usb ID to pay attention to.

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,11 +28,28 @@ impl usb::UsbCallback for App {
                 wake_displays().map_err(|err| error!("{:?}", err));
             });
             display_control::switch_to(self.config.monitor_input);
-        }
+            // Apparently, for my monitor (a iiyama PL2779Q) you have to yell
+            display_control::switch_to(self.config.monitor_input);
+            display_control::switch_to(self.config.monitor_input);
+        }    
     }
 
+    #[allow(unused_must_use)]
     fn device_removed(&self, device_id: &str) {
         debug!("Detected device change. Removed device: {:?}", device_id);
+        if device_id == self.config.usb_device {
+			info!(
+				"Detected the device we're looking for {:?}, switching to other input",
+				&self.config.usb_device
+			);
+			std::thread::spawn(|| {
+				wake_displays().map_err(|err| error!("{:?}", err));
+			});
+			display_control::switch_to(self.config.monitor_other);
+            // Apparently, for my monitor (a iiyama PL2779Q) you have to yell
+			display_control::switch_to(self.config.monitor_other);
+			display_control::switch_to(self.config.monitor_other);
+		}
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -14,6 +14,7 @@ use crate::display_control;
 pub struct Configuration {
     pub usb_device: String,
     pub monitor_input: display_control::InputSource,
+    pub monitor_other: display_control::InputSource,
 }
 
 impl Configuration {

--- a/src/platform/display_control_macos.rs
+++ b/src/platform/display_control_macos.rs
@@ -22,7 +22,7 @@ impl DdcControlTrait for DdcControlMacos {
     }
 
     fn ddc_read_input_select(display_idx: isize) -> Result<u16> {
-        let source = unsafe { ddcReadInputSelect(display_idx) };
+       let source = unsafe { ddcReadInputSelect(display_idx) };
         if source > 0 {
             info!(
                 "Display '{:?}' is currently set to 0x{:x}",


### PR DESCRIPTION
Three changes suggested here:
1) added the lsusb information for Macs to the readme.

2) set things up so that I only have to run this on one Mac.  That's important to me because the other Mac is a work Mac, and even if it's not so locked down that I can't do this, I suspect they'd frown upon it.

3) Set the display (both directions) three times.  My IIyama PL2779Q doesn't hear if it's only set once.  You have to really get its attention, I guess.