### PR TITLE
Return a Result from main()

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,8 @@
 // This code is licensed under MIT license (see LICENSE.txt for details)
 //
 
+use anyhow::Result;
+
 use crate::configuration::{Configuration, SwitchDirection};
 use crate::display_control;
 use crate::logging;
@@ -36,21 +38,18 @@ impl usb::UsbCallback for App {
 }
 
 impl App {
-    pub fn new() -> Self {
-        logging::init_logging().unwrap();
-        let config = match Configuration::load() {
-            Ok(config) => config,
-            Err(err) => {
-                error!("Could not load configuration: {:?}", err);
-                panic!("Configuration error")
-            }
-        };
-        Self { config }
+    pub fn new() -> Result<Self> {
+        logging::init_logging()?;
+        let config = Configuration::load()?;
+
+        Ok(Self { config })
     }
 
-    pub fn run(self) {
+    pub fn run(self) -> Result<()> {
         display_control::log_current_source();
         let pnp_detector = PnPDetect::new(Box::new(self));
-        pnp_detector.detect().unwrap();
+        pnp_detector.detect()?;
+
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@
 #[macro_use]
 extern crate log;
 
+use anyhow::Result;
+
 mod app;
 mod configuration;
 mod display_control;
@@ -15,7 +17,9 @@ mod logging;
 mod platform;
 mod usb;
 
-fn main() {
-    let app = app::App::new();
-    app.run();
+fn main() -> Result<()> {
+    let app = app::App::new()?;
+    app.run()?;
+
+    Ok(())
 }


### PR DESCRIPTION
Change `main` to return a Result. Fatal errors can be propagated up to `main`,
which will print the error message and exit with a failure code.

Update `app` to return errors instead of panicking.

Before:

```
19:29:12 [ERROR] Could not load configuration: configuration file "/Users/user/Library/Preferences/display-switch.ini" not found
thread 'main' panicked at 'Configuration error', src/app.rs:45:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```
Error: configuration file "/Users/user/Library/Preferences/display-switch.ini" not found
```