### PR TITLE
Change binary name from display_switch to display-switch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
         run: cargo test --verbose
 
       - name: Run executable
-        run: ./target/release/display_switch || true # todo: --version or --help when those exist
+        run: ./target/release/display-switch || true # todo: --version or --help when those exist
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}
           if-no-files-found: error
           path: |
-            target/release/display_switch
-            target/release/display_switch.exe
+            target/release/display-switch
+            target/release/display-switch.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "display_switch"
+name = "display-switch"
 version = "0.3.0"
 dependencies = [
  "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "display_switch"
+name = "display-switch"
 version = "0.3.0"
 authors = ["Haim Gelfenbeyn <haim@g8n.me>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In the command output, the highlighted lines show you which USB IDs are most rel
 
 ### Windows
 
-Copy `display_switch.exe` from `target\release` (where it was built in the previous step) to 
+Copy `display-switch.exe` from `target\release` (where it was built in the previous step) to 
 `C:\Users\Username\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup` (replace Username with your 
 Windows user name).
 
@@ -105,7 +105,7 @@ Windows user name).
 
 ```bash
   # Get your INI file in order! (see above)
-  cp target/release/display_switch /usr/local/bin
+  cp target/release/display-switch /usr/local/bin
   cp dev.haim.display-switch.daemon.plist ~/Library/LaunchAgents/
   launchctl load ~/Library/LaunchAgents/dev.haim.display-switch.daemon.plist
 ```

--- a/dev.haim.display-switch.daemon.plist
+++ b/dev.haim.display-switch.daemon.plist
@@ -5,7 +5,7 @@
         <key>Label</key>
         <string>dev.haim.display-switch.daemon</string>
         <key>Program</key>
-        <string>/usr/local/bin/display_switch</string>
+        <string>/usr/local/bin/display-switch</string>
         <key>RunAtLoad</key>
         <true/>
     </dict>


### PR DESCRIPTION
Change crate name to `display-swtich`. This changes the binary name from
`display_switch` to `display-switch`.