### PR TITLE
Add context to configuration and logging errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@
 // This code is licensed under MIT license (see LICENSE.txt for details)
 //
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::configuration::{Configuration, SwitchDirection};
 use crate::display_control;
@@ -39,8 +39,8 @@ impl usb::UsbCallback for App {
 
 impl App {
     pub fn new() -> Result<Self> {
-        logging::init_logging()?;
-        let config = Configuration::load()?;
+        logging::init_logging().context("failed to initialize logging")?;
+        let config = Configuration::load().context("failed to load configuration")?;
 
         Ok(Self { config })
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::input_source::InputSource;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
 
@@ -102,7 +102,8 @@ impl Configuration {
                 .ok_or_else(|| anyhow!("Config directory not found"))?
                 .join("display-switch")
         };
-        std::fs::create_dir_all(&config_dir)?;
+        std::fs::create_dir_all(&config_dir)
+            .with_context(|| format!("failed to create directory: {:?}", config_dir))?;
         Ok(config_dir.join("display-switch.ini"))
     }
 
@@ -118,7 +119,7 @@ impl Configuration {
                 .ok_or_else(|| anyhow!("Data-local directory not found"))?
                 .join("display-switch")
         };
-        std::fs::create_dir_all(&log_dir)?;
+        std::fs::create_dir_all(&log_dir).with_context(|| format!("failed to create directory: {:?}", log_dir))?;
         Ok(log_dir.join("display-switch.log"))
     }
 


### PR DESCRIPTION
Add context configuration or logging errors.

Here is an example of an error with context information:

```
$ HOME=/root target/debug/display_switch
Error: failed to initialize logging

Caused by:
    0: failed to create directory: "/root/.local/share/display-switch"
    1: Permission denied (os error 13)
```