### PR TITLE
Increase display() retry delay to 3 seconds

### DIFF
--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -11,7 +11,7 @@ use std::{thread, time};
 
 /// VCP feature code for input select
 const INPUT_SELECT: u8 = 0x60;
-const RETRY_DELAY_MS: u64 = 2000;
+const RETRY_DELAY_MS: u64 = 3000;
 
 fn display_name(display: &Display, index: Option<usize>) -> String {
     if let Some(index) = index {


### PR DESCRIPTION
In #49 we added a 2 second retry when invoking `Display::enumerate()`. I noticed a few cases where 2 seconds was insufficient, but in my testing 3 seconds proved reliable. Perhaps this could benefit from a progressive retry scheme, but I wasn't sure if the complexity would be worthwhile to improve support for this edge-case, so I've instead bumped the retry delay to 3 seconds.