### PR TITLE
Added Dvi1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configuration file settings:
 ```
 
 `usb_device` is which USB device to watch (vendor id / device id in hex), and `on_usb_connect` is which monitor input
-to switch to, when this device is connected. Supported values are `Hdmi1`, `Hdmi2`, `DisplayPort1`, `DisplayPort2`.
+to switch to, when this device is connected. Supported values are `Hdmi1`, `Hdmi2`, `DisplayPort1`, `DisplayPort2`, `Dvi1`.
 If your monitor has an USB-C port, it's usually reported as `DisplayPort2`. Input can also be specified as a "raw"
 decimal or hexadecimal value: `on_usb_connect = 0x10`
 

--- a/src/input_source.rs
+++ b/src/input_source.rs
@@ -49,6 +49,7 @@ symbolic_input_source! {
     DisplayPort2: 0x10
     Hdmi1: 0x11
     Hdmi2: 0x12
+    Dvi1: 0x3
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
My monitors support Dvi1 and seems to be a valid input. Adding this value to the enumeration appears to work using 0x3.

Thanks for this tool - extremely helpful.