### PR TITLE
add --version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo test
 
       - name: Run executable
-        run: ./target/release/display_switch || true # todo: --version or --help when those exist
+        run: ./target/release/display_switch --version
 
       - uses: actions/upload-artifact@v2
         with:

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 extern crate log;
 
 use anyhow::Result;
+use std::env;
 
 #[cfg(target_os = "windows")]
 use winapi::um::wincon::{AttachConsole, ATTACH_PARENT_PROCESS};
@@ -30,6 +31,11 @@ fn attach_console() {
 }
 
 fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 2 && args[1] == "--version" {
+        println!("{} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
     attach_console();
     let app = app::App::new()?;
     app.run()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,14 @@ fn attach_console() {
 }
 
 fn main() -> Result<()> {
+    attach_console();
+
     let args: Vec<String> = env::args().collect();
     if args.len() == 2 && args[1] == "--version" {
         println!("{} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
-    attach_console();
+
     let app = app::App::new()?;
     app.run()?;
     Ok(())


### PR DESCRIPTION
Seems like this might be useful, and it addresses a TODO I left in the CI config a long time ago.

(so now the "Run executable" CI check is slightly improved, in that it could fail the job if something goes wrong)

I didn't add a parsing library, since there's just the one CLI option for now, but something like [clap](https://crates.io/crates/clap) or [structopt](https://crates.io/crates/structopt) might make sense in the future.