### PR TITLE
Don't switch source when already set

### DIFF
--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -50,7 +50,7 @@ fn are_display_names_unique(displays: &[Display]) -> bool {
 fn try_switch_display(handle: &mut Handle, display_name: &str, input: InputSource) {
 	match handle.get_vcp_feature(INPUT_SELECT) {
 		Ok(raw_source) => {
-			if raw_source.value() == input.value() {
+			if raw_source.value() & 0xff == input.value() {
 				info!("Display {} is already set to {}", display_name, input);
 				return;
 			}


### PR DESCRIPTION
When (re)starting the service, my monitor would flicker off while it re-applied the input.

Since there already was code to get the current source, I decided to add a check to skip setting the source if already set to the desired value.

Not really familiar with rust, so feel free to edit or make your own version.

Also, it might make sense to make this configurable, as mentioned in #30 and xkcd 1172.