### PR TITLE
Include stdout & stderr from executed command when it fails

### DIFF
--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -130,18 +130,35 @@ fn run_command(execute_command: &str) {
         }
 
         let executable = arguments.remove(0);
-        let result = Command::new(executable)
-            .args(arguments)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?
-            .wait()?;
-        return if result.success() {
+        let output = Command::new(executable).args(arguments).stdin(Stdio::null()).output()?;
+        return if output.status.success() {
             info!("External command '{}' executed successfully", execute_command);
             Ok(())
         } else {
-            Err(Error::msg(format!("Exited with status {}", result)))
+            let msg = if let Some(code) = output.status.code() {
+                format!("Exited with status {}\n", code)
+            } else {
+                "Exited because of a signal\n".to_string()
+            };
+            let stdout = if !output.stdout.is_empty() {
+                if let Ok(s) = String::from_utf8(output.stdout) {
+                    format!("Stdout = [{}]\n", s)
+                } else {
+                    format!("Stdout was not UTF-8")
+                }
+            } else {
+                "No stdout\n".to_string()
+            };
+            let stderr = if !output.stderr.is_empty() {
+                if let Ok(s) = String::from_utf8(output.stderr) {
+                    format!("Stderr = [{}]\n", s)
+                } else {
+                    format!("Stderr was not UTF-8")
+                }
+            } else {
+                "No stderr\n".to_string()
+            };
+            Err(Error::msg(format!("{} {} {}", msg, stdout, stderr)))
         };
     }
 


### PR DESCRIPTION
This makes debugging issues with on_usb_(dis)connect_execute commands much easier.