### PR TITLE
Update rusb dependency to ^0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "display_switch"
-version = "1.2.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "config",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "libusb1-sys"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+checksum = "f9d0e2afce4245f2c9a418511e5af8718bcaf2fa408aefb259504d1a9cb25f27"
 dependencies = [
  "cc",
  "libc",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "rusb"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c470dc7dc6e4710b6f85e9c4aa4650bc742260b39a36328180578db76fa258c1"
+checksum = "703aa035c21c589b34fb5136b12e68fc8dcf7ea46486861381361dd8ebf5cee0"
 dependencies = [
  "libc",
  "libusb1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "^1.0"
 log = "^0.4"
 simplelog = "^0.12"
 ddc = "^0.2"
-rusb = "^0.7"
+rusb = "^0.9.1"
 shell-words = "^1"
 ddc-hi = "0.4.1"
 

--- a/src/platform/pnp_detect_libusb.rs
+++ b/src/platform/pnp_detect_libusb.rs
@@ -5,12 +5,12 @@
 
 use crate::usb::{device2str, UsbCallback};
 use anyhow::{anyhow, Result};
-use rusb::{Context, Device, UsbContext};
+use rusb::{Context, Device, HotplugBuilder, UsbContext, Registration};
 
 /// Detection of plugged in / removed USB devices: uses "libusb" and should work on Linux
 /// and MacOS, but not on Windows: libusb does not support hotplug on Windows.
 pub struct PnPDetectLibusb {
-    callback: Box<dyn UsbCallback>,
+    callback: Box<dyn UsbCallback + Send>,
 }
 
 impl<T: UsbContext> rusb::Hotplug<T> for PnPDetectLibusb {
@@ -28,14 +28,20 @@ impl<T: UsbContext> rusb::Hotplug<T> for PnPDetectLibusb {
 }
 
 impl PnPDetectLibusb {
-    pub fn new(callback: Box<dyn UsbCallback>) -> Self {
+    pub fn new(callback: Box<dyn UsbCallback + Send>) -> Self {
         PnPDetectLibusb { callback }
     }
 
     pub fn detect(self) -> Result<()> {
         if rusb::has_hotplug() {
-            let context = Context::new().unwrap();
-            context.register_callback(None, None, None, Box::new(self)).unwrap();
+            let context = Context::new()?;
+
+            let mut _reg: std::option::Option<Registration<rusb::Context>> = Some(
+               HotplugBuilder::new()
+                   .enumerate(true)
+                   .register(&context, Box::new(self))?,
+            );
+
             loop {
                 if let Err(err) = context.handle_events(None) {
                     error!("Error during USB errors handling: {:?}", err)


### PR DESCRIPTION
As part of the update, the context.register_callback() has been deprecated in
favor of HotplugBuilder, so change the code to use that method instead.

This also seems to solve https://github.com/haimgel/display-switch/issues/110