### PR TITLE
Add how to rename Windows monitor_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ on_usb_connect = "hdmi2"
 `LEN P27u-10 S/N 1144206897` monitor ID. If more than one section has a match, a first one will be used.
 `on_usb_connect` and `on_usb_disconnect`, if defined, take precedence over global defaults.
 
+_Tips for Windows_: monitors can be renamed at
+`\HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Enum\DISPLAY\{MODEL_ID}\{CONNECTION_ID}\DeviceDesc` after the last semicolon
+in case they are all just "Generic PnP Monitor".
+
 ### Running external commands
 `display-switch` supports running external commands upon connection or disconnection of USB devices. This configuration
 can be global (runs every time a configured USB device is connected or disconnected) or per-monitor (runs only when

--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ on_usb_connect = "hdmi2"
 `LEN P27u-10 S/N 1144206897` monitor ID. If more than one section has a match, a first one will be used.
 `on_usb_connect` and `on_usb_disconnect`, if defined, take precedence over global defaults.
 
-_Tips for Windows_: monitors can be renamed at
-`\HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Enum\DISPLAY\{MODEL_ID}\{CONNECTION_ID}\DeviceDesc` after the last semicolon
-in case they are all just "Generic PnP Monitor".
+_Tips for Windows_: monitors can be renamed in the Registry at
+`\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\DISPLAY\{MODEL_ID}\{CONNECTION_ID}`. Edit the `DeviceDesc` value and change the name after the last semicolon. This is especially helpful in case they are all just "Generic PnP Monitor".
 
 ### Running external commands
 `display-switch` supports running external commands upon connection or disconnection of USB devices. This configuration


### PR DESCRIPTION
Hi!

I have run into unfortunate case where the index of "Generic PnP monitor" is not stable and I found [this issue](https://github.com/haimgel/display-switch/issues/33#issuecomment-699929672). After some exploration it turned out that we should edit `DeviceDesc` instead of `FriendlyName` to change the monitor id.

I believe this worth documenting so this PR.

![snapshot](https://user-images.githubusercontent.com/20200613/191582666-235534a4-408b-4b6c-914a-6683d5662f51.png)

