### PR TITLE
Add composite video values

### DIFF
--- a/src/input_source.rs
+++ b/src/input_source.rs
@@ -49,6 +49,8 @@ symbolic_input_source! {
     DisplayPort2: 0x10
     Hdmi1: 0x11
     Hdmi2: 0x12
+    CompositeVideo1: 0x05
+    CompositeVideo2: 0x06
     Dvi1: 0x3
     Dvi2: 0x4
     Vga1: 0x1


### PR DESCRIPTION
Samsung G95NC has 3 HDMI ports and reports one of them as 0x05