### PR TITLE
Support multiple command executions with on_usb_<event>_execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Notes:
 2. This program supports splitting supplied configuration into application name and parameters, but no other shell features are supported.
 3. If the application path contains spaces, surround the full file path with single quotes.
 4. On Windows, escape the backslashes (replace \ with \\, see the example above).
+5. Multiple commands can be chained by separating them with a semicolumn ";", like in a shell.
 
 ### USB Device IDs
 

--- a/src/display_control.rs
+++ b/src/display_control.rs
@@ -177,6 +177,10 @@ fn run_command(execute_command: &str) {
         }
     }
 
-    try_run_command(execute_command)
-        .unwrap_or_else(|err| error!("Error executing external command '{}': {}", execute_command, err))
+    for subcommand in execute_command.split(";") {
+        let subcommand = subcommand.trim();
+        if !subcommand.is_empty() {
+            try_run_command(subcommand).unwrap_or_else(|err| error!("Error executing external command '{}': {}", subcommand, err));
+        }
+    }
 }


### PR DESCRIPTION
As proposed in #133, a quick fix to support multiple command executions with `on_usb_<event>_execute`.

Happy to discuss alternative options !