### PR TITLE
Move nvapi dependency to windows target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ ddc-macos = "^0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ddc-i2c = "^0.2"
-nvapi = "^0.1"
 uinput = "^0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "^0.3", features = ["winuser", "libloaderapi"] }
 ddc-winapi = "^0.2"
+nvapi = "^0.1"


### PR DESCRIPTION
NVAPI only works on Windows, should not build it on other targets.