### PR TITLE
Add always_switch optional config for Acer monitors that don't correctly report they are on the usb-c input

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 Haim Gelfenbeyn
+Copyright (c) 2024 Luke Nuttall
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Configuration file settings:
 ```ini
   usb_device = "1050:0407"
   on_usb_connect = "Hdmi1"
-  on_usb_disconnect = "Hdmi2"
+  on_usb_disconnect = "Hdmi2"  
+  always_switch = true
 ```
 
 `usb_device` is which USB device to watch (vendor id / device id in hex), and `on_usb_connect` is which monitor input
@@ -41,6 +42,10 @@ decimal or hexadecimal value: `on_usb_connect = 0x10`
 The optional `on_usb_disconnect` settings allows to switch in the other direction when the USB device is disconnected.
 Note that the preferred way is to have this app installed on both computers. Switching "away" is problematic: if the
 other computer has put the monitors to sleep, they will switch immediately back to the original input.
+
+The optional `always_switch` setting can be used to attempt to switch even if the monitor reports that it currently
+on the input we want to switch to. This is useful for Acer monitors like the XR343CRK, which pretend they are still
+connected to `DisplayPort1` or `0xF`, when you switch to USB-C using `DisplayPort2` or `0x10`.
 
 ### Different inputs on different monitors
 `display-switch` supports per-monitor configuration: add one or more monitor-specific configuration sections to set

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,5 +1,6 @@
 //
 // Copyright © 2020 Haim Gelfenbeyn
+// Copyright © 2020 Luke Nuttall
 // This code is licensed under MIT license (see LICENSE.txt for details)
 //
 
@@ -35,6 +36,9 @@ struct PerMonitorConfiguration {
 pub struct Configuration {
     #[serde(deserialize_with = "Configuration::deserialize_usb_device")]
     pub usb_device: String,
+    #[serde(default)]
+    #[serde(deserialize_with = "Configuration::deserialize_always_switch")]
+    pub always_switch: bool,
     #[serde(flatten)]
     pub default_input_sources: InputSources,
     monitor1: Option<PerMonitorConfiguration>,
@@ -106,6 +110,14 @@ impl Configuration {
     {
         let s: String = Deserialize::deserialize(deserializer)?;
         Ok(s.to_lowercase())
+    }
+
+    fn deserialize_always_switch<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let b: bool = Deserialize::deserialize(deserializer)?;
+        Ok(b)
     }
 
     pub fn config_file_name() -> Result<std::path::PathBuf> {
@@ -197,6 +209,45 @@ mod tests {
         .unwrap();
         assert_eq!(config.usb_device, "dead:beef")
     }
+
+    #[test]
+    fn test_always_switch_is_true_deserialization() {
+        let config = load_test_config(
+            r#"
+            usb_device = "dead:BEEF"
+            always_switch = true
+            on_usb_connect = "DisplayPort2"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(config.always_switch, true)
+    }
+
+    #[test]
+    fn test_always_switch_is_false_deserialization() {
+        let config = load_test_config(
+            r#"
+            usb_device = "dead:BEEF"
+            always_switch = false
+            on_usb_connect = "DisplayPort2"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(config.always_switch, false)
+    }
+
+    #[test]
+    fn test_always_switch_defaults_to_false_deserialization() {
+        let config = load_test_config(
+            r#"
+            usb_device = "dead:BEEF"
+            on_usb_connect = "DisplayPort2"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(config.always_switch, false)
+    }
+
 
     #[test]
     fn test_symbolic_input_deserialization() {


### PR DESCRIPTION
Some Acer monitors continue to report that they are on DisplayPort1 when they've been switched to the usb-c input (using DisplayPort2). This fork adds a config setting so that display_switch can force a switch attempt even if the monitor is lying to us.

I don't know if you accept PRs, but feel free.