### PR TITLE
Apple Silicon Macs support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ on:
       - main
     tags:
       - '**'
-    pull_request:
-      types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "bitflags"
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
 dependencies = [
  "shlex",
 ]
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -107,11 +107,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -120,11 +120,11 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "libc",
 ]
@@ -147,16 +147,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba69f2c53e320fc4abad17cb02bbbf04d1a36f18e9907f347589ec5991b3c6c5"
 dependencies = [
- "mccs 0.1.3",
-]
-
-[[package]]
-name = "ddc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1363c64a5107a51aa7a4198f7a0a61e3ae2347737ef26360dbd7f6025d6ee4f0"
-dependencies = [
- "mccs 0.2.0",
+ "mccs",
 ]
 
 [[package]]
@@ -166,13 +157,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6747b17c926a2aa34739b30f1a6cc726e3a7baf0e2f69a4c03a95cf5de94de"
 dependencies = [
  "anyhow",
- "ddc 0.2.2",
+ "ddc",
  "ddc-i2c",
  "ddc-macos",
  "ddc-winapi",
  "edid",
  "log",
- "mccs 0.1.3",
+ "mccs",
  "mccs-caps",
  "mccs-db",
  "nvapi",
@@ -184,7 +175,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ef18fac9fd5c11d0c7b85a80887b01f7361b49edb2b4627243928b90ce2691b"
 dependencies = [
- "ddc 0.2.2",
+ "ddc",
  "i2c",
  "i2c-linux",
  "resize-slice",
@@ -192,14 +183,13 @@ dependencies = [
 
 [[package]]
 name = "ddc-macos"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d04c521a076cbd37159b4674492304407f3bbc9669b43a90d9ed054a6d2b3cb"
+version = "0.2.2"
+source = "git+https://github.com/haimgel/ddc-macos-rs.git?branch=feature/mac-m3-support#a1355251f6b6300f6c143791f2efff3c06a2ff0a"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "core-graphics",
- "ddc 0.2.2",
+ "ddc",
  "io-kit-sys",
  "mach",
  "thiserror",
@@ -211,7 +201,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b65693556bdf54c77e0c82db4951686e4f030e7eb1c643d1bc781de2a4bce35"
 dependencies = [
- "ddc 0.2.2",
+ "ddc",
  "widestring",
  "winapi",
 ]
@@ -252,7 +242,7 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "config",
- "ddc 0.3.0",
+ "ddc",
  "ddc-hi",
  "ddc-i2c",
  "ddc-macos",
@@ -502,18 +492,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mccs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a63ab5297c9a7d5f8298a076b5f858c3c51ce84bf2f57a302d1d67ff9323360"
-
-[[package]]
 name = "mccs-caps"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb961d01a3bb07969cfa276be2ab88c31d0fefa77a872696832732d6e9ec094"
 dependencies = [
- "mccs 0.1.3",
+ "mccs",
  "nom 3.2.1",
 ]
 
@@ -523,7 +507,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cdaa8fe19a1a1918becc1b8cbbbdc1058bc71411dff4de0a6ec6b5269f49d38"
 dependencies = [
- "mccs 0.1.3",
+ "mccs",
  "nom 3.2.1",
  "serde",
  "serde_derive",
@@ -804,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.86"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -824,18 +808,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
+checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
+checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,14 +184,15 @@ dependencies = [
 [[package]]
 name = "ddc-macos"
 version = "0.2.2"
-source = "git+https://github.com/haimgel/ddc-macos-rs.git?branch=feature/mac-m3-support#a1355251f6b6300f6c143791f2efff3c06a2ff0a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aca22e30b33daf41a5d269a19b00588adf5242ed5525d3818195de17a534dc"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "core-graphics",
  "ddc",
  "io-kit-sys",
- "mach",
+ "mach2",
  "thiserror",
 ]
 
@@ -253,7 +254,6 @@ dependencies = [
  "paste",
  "rusb",
  "serde",
- "serde_json",
  "shell-words",
  "simplelog",
  "uinput",
@@ -463,15 +463,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mach2"
@@ -714,12 +705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "serde"
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,18 +722,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.132"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
-dependencies = [
- "itoa",
- "memchr 2.7.4",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "^1.0", features = ["derive"] }
 anyhow = "^1.0"
 log = "^0.4"
 simplelog = "^0.12"
-ddc = "^0.3"
+ddc = "^0.2"
 rusb = "^0.9"
 shell-words = "^1"
 ddc-hi = "0.4.1"
@@ -36,3 +36,6 @@ uinput = "^0.1"
 winapi = { version = "^0.3", features = ["winuser", "libloaderapi", "wincon"] }
 ddc-winapi = "^0.2"
 nvapi = "^0.1"
+
+[patch.crates-io]
+ddc-macos = { git = "https://github.com/haimgel/ddc-macos-rs.git", branch = "feature/mac-m3-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,11 @@ log = "0.4"
 simplelog = "0.12"
 ddc = "0.2"
 ddc-hi = "0.4"
-ddc-macos = "0.2.2"
 rusb = "^0.9"
 shell-words = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ddc-macos = "0.2"
+ddc-macos = "0.2.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ddc-i2c = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,34 +8,28 @@ readme = "README.md"
 repository = "https://github.com/haimgel/display-switch/"
 license = "MIT"
 
-[build-dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-
 [dependencies]
-config = { version = "^0.14", features = ["ini"], default-features = false }
-paste = "^1"
-dirs = "^5.0"
-serde = { version = "^1.0", features = ["derive"] }
-anyhow = "^1.0"
-log = "^0.4"
-simplelog = "^0.12"
-ddc = "^0.2"
+config = { version = "0.14", features = ["ini"], default-features = false }
+paste = "1.0"
+dirs = "5.0"
+serde = { version = "1.0", features = ["derive"] }
+anyhow = "1.0"
+log = "0.4"
+simplelog = "0.12"
+ddc = "0.2"
+ddc-hi = "0.4"
+ddc-macos = "0.2.2"
 rusb = "^0.9"
-shell-words = "^1"
-ddc-hi = "0.4.1"
+shell-words = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ddc-macos = "^0.2"
+ddc-macos = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-ddc-i2c = "^0.2"
-uinput = "^0.1"
+ddc-i2c = "0.2"
+uinput = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "^0.3", features = ["winuser", "libloaderapi", "wincon"] }
-ddc-winapi = "^0.2"
-nvapi = "^0.1"
-
-[patch.crates-io]
-ddc-macos = { git = "https://github.com/haimgel/ddc-macos-rs.git", branch = "feature/mac-m3-support" }
+winapi = { version = "0.3", features = ["winuser", "libloaderapi", "wincon"] }
+ddc-winapi = "0.2"
+nvapi = "0.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 max_width = 120
-edition = "2021"
+style_edition = "2021"
 use_try_shorthand = true


### PR DESCRIPTION
Integrating latest `ddc-macos-rs` crate, where I've added M1/M2/M3 support.