### PR TITLE
docs: add additional command for debugging vendor and product ids on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ $ opendiff a b
 ```
 In the command output, the highlighted lines show you which USB IDs are most relevant.
 
+
+For a full list of USB devices:
+```
+system_profiler SPUSBDataType
+```
+**Important**: The format for your display-switch.ini is VendorID:ProductID. VendorID is displyed *second* in the `system_profiler` output
+
 #### Linux
 Requires additional packages, install via: `sudo apt install libxi-dev xorg-dev`
 


### PR DESCRIPTION
Adding this to the docs because I found it a lot easier to understand. It shows the entire USB tree.

![image](https://github.com/user-attachments/assets/a104f64f-6a0b-4ff7-8434-885f4646b516)
